### PR TITLE
fix(feature-flags): remove better-call dependency, improve type safety

### DIFF
--- a/docs/feature-flags/client-sdk.md
+++ b/docs/feature-flags/client-sdk.md
@@ -9,22 +9,21 @@ Install the client SDK with your package manager:
 ::: code-group
 
 ```bash [bun]
-bun add better-auth better-call better-auth-feature-flags
+bun add better-auth better-auth-feature-flags
 ```
 
 ```bash [npm]
-npm install better-auth better-call better-auth-feature-flags
+npm install better-auth better-auth-feature-flags
 ```
 
 ```bash [pnpm]
-pnpm add better-auth better-call better-auth-feature-flags
+pnpm add better-auth better-auth-feature-flags
 ```
 
 > Note
 >
-> - `better-auth` and `better-call` are peer dependencies of this package.
-> - `better-call` is the transport/middleware layer Better Auth uses under the hood and this plugin’s middleware relies on it as well.
-> - Use compatible versions (e.g., `better-auth@^1.3.11`, `better-call@^1.0.19`) to ensure type and runtime alignment.
+> - `better-auth` is a peer dependency of this package.
+> - Use a compatible version (e.g., `better-auth@^1.3.11`) to ensure type and runtime alignment.
 
 :::
 
@@ -1055,8 +1054,8 @@ interface MyFlags {
 }
 
 // Create typed client
-const client = createAuthClient<MyFlags>({
-  plugins: [featureFlagsClient()],
+const client = createAuthClient({
+  plugins: [featureFlagsClient<MyFlags>()],
 });
 
 // Now fully typed

--- a/docs/feature-flags/quickstart.md
+++ b/docs/feature-flags/quickstart.md
@@ -9,26 +9,25 @@ Install the feature flags plugin alongside Better Auth:
 ::: code-group
 
 ```bash [bun]
-bun add better-auth better-call better-auth-feature-flags
+bun add better-auth better-auth-feature-flags
 ```
 
 ```bash [npm]
-npm install better-auth better-call better-auth-feature-flags
+npm install better-auth better-auth-feature-flags
 ```
 
 ```bash [pnpm]
-pnpm add better-auth better-call better-auth-feature-flags
+pnpm add better-auth better-auth-feature-flags
 ```
 
 ```bash [yarn]
-yarn add better-auth better-call better-auth-feature-flags
+yarn add better-auth better-auth-feature-flags
 ```
 
 > Note
 >
-> - `better-auth` and `better-call` are peer dependencies of the feature flags plugin.
-> - `better-call` is the HTTP API/middleware foundation used by Better Auth and this plugin. Better Auth depends on it and re-exports some of its types.
-> - Install matching versions (e.g., `better-auth@^1.3.11`, `better-call@^1.0.19`) to avoid package resolution issues.
+> - `better-auth` is a peer dependency of the feature flags plugin.
+> - Install a matching version (e.g., `better-auth@^1.3.11`) to avoid package resolution issues.
 
 :::
 

--- a/plugins/feature-flags/README.md
+++ b/plugins/feature-flags/README.md
@@ -46,23 +46,22 @@ Enterprise-grade feature flag management integrated with Better Auth. Control fe
 
 ```bash
 # npm
-npm install better-auth better-call better-auth-feature-flags
+npm install better-auth better-auth-feature-flags
 
 # bun
-bun add better-auth better-call better-auth-feature-flags
+bun add better-auth better-auth-feature-flags
 
 # pnpm
-pnpm add better-auth better-call better-auth-feature-flags
+pnpm add better-auth better-auth-feature-flags
 
 # yarn
-yarn add better-auth better-call better-auth-feature-flags
+yarn add better-auth better-auth-feature-flags
 ```
 
 ### Peer Dependencies
 
-- This plugin lists `better-auth` and `better-call` as peer dependencies.
-- `better-call` is the request/response + middleware layer Better Auth builds on and is also used by this plugin’s server middleware. Better Auth depends on it and re-exports some of its types.
-- Installing both `better-auth@^1.3.11` and `better-call@^1.0.19` ensures consistent versions and avoids hoisting/resolution issues under pnpm and other strict package managers.
+- This plugin requires `better-auth` as a peer dependency.
+- Install a compatible version (e.g., `better-auth@^1.3.11`) to ensure proper type and runtime alignment.
 
 ## Quick Start
 

--- a/plugins/feature-flags/package.json
+++ b/plugins/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-auth-feature-flags",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Ship features safely with feature flags, A/B testing, and progressive rollouts - Better Auth plugin for modern release management",
   "keywords": [
     "better-auth",

--- a/plugins/feature-flags/src/client.ts
+++ b/plugins/feature-flags/src/client.ts
@@ -7,6 +7,7 @@ import { ContextSanitizer } from "./context-sanitizer";
 import { SecureOverrideManager, type OverrideConfig } from "./override-manager";
 import type { FeatureFlagsServerPlugin } from "./plugin";
 import { SmartPoller } from "./polling";
+import type { BooleanFlags } from "./types";
 
 export type { EvaluationContext } from "./schema/types";
 export type { BooleanFlags, InferFlagValue, ValidateFlagSchema } from "./types";
@@ -117,8 +118,8 @@ export interface FeatureFlagsClient<
 > {
   featureFlags: {
     /** Check if boolean flag is enabled */
-    isEnabled: <K extends keyof Schema>(
-      flag: K & { [P in K]: Schema[P] extends boolean ? K : never }[K],
+    isEnabled: <K extends BooleanFlags<Schema>>(
+      flag: K,
       defaultValue?: boolean,
     ) => Promise<boolean>;
     /** Get typed flag value with fallback */
@@ -566,8 +567,8 @@ export function featureFlagsClient<
 
       const actions = {
         featureFlags: {
-          async isEnabled<K extends keyof Schema>(
-            flag: K & { [P in K]: Schema[P] extends boolean ? K : never }[K],
+          async isEnabled<K extends BooleanFlags<Schema>>(
+            flag: K,
             defaultValue = false,
           ): Promise<boolean> {
             const result = await evaluateFlag(flag);

--- a/plugins/feature-flags/src/index.ts
+++ b/plugins/feature-flags/src/index.ts
@@ -4,11 +4,11 @@
 // Type augmentations only - no runtime imports to preserve tree-shaking
 import type {} from "./augmentation";
 
-import { createFeatureFlagsPlugin } from "./plugin";
 import type { BetterAuthPlugin } from "better-auth";
-import type { FeatureFlagsOptions } from "./types";
 import type { FlagEndpoints } from "./endpoints";
 import { definePlugin } from "./internal/define-plugin";
+import { createFeatureFlagsPlugin } from "./plugin";
+import type { FeatureFlagsOptions } from "./types";
 
 /**
  * Better Auth Feature Flags Plugin
@@ -70,3 +70,11 @@ export { DEFAULT_HEADER_CONFIG } from "./middleware/validation";
 export type { HeaderConfig, ValidationConfig } from "./middleware/validation";
 // Main plugin configuration interface
 export type { FeatureFlagsOptions } from "./types";
+
+// Client types for application developers
+export type {
+  FeatureFlagResult,
+  FeatureFlagsClient,
+  FeatureFlagsClientOptions,
+  FeatureFlagVariant,
+} from "./client";

--- a/plugins/feature-flags/test/architecture/no-better-call-imports.test.ts
+++ b/plugins/feature-flags/test/architecture/no-better-call-imports.test.ts
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2025-present Kriasoft
+// SPDX-License-Identifier: MIT
+
+import { describe, it } from "bun:test";
+import { readdir, readFile } from "fs/promises";
+import { dirname, join, relative, resolve } from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * Enforces no imports from 'better-call' package.
+ *
+ * WHY: Migrated away from better-call to fix TypeScript "excessively deep" errors
+ * and reduce bundle size. All middleware functionality moved to src/middleware/
+ *
+ * @see plugins/feature-flags/specs/types-spec.md - Migration details
+ * @see src/middleware/ - Internal implementations
+ */
+describe("better-call imports", () => {
+  it("should not import from better-call in any source files", async () => {
+    const testDir = dirname(fileURLToPath(import.meta.url));
+    const srcDir = resolve(testDir, "../../src");
+    const sourceFiles = await getAllSourceFiles(srcDir);
+    const violatingFiles: Array<{ file: string; lines: string[] }> = [];
+
+    for (const file of sourceFiles) {
+      const content = await readFile(file, "utf-8");
+      const lines = content.split("\n");
+      const betterCallImports: string[] = [];
+
+      lines.forEach((line, index) => {
+        // Skip comments to avoid false positives
+        const trimmedLine = line.trim();
+        if (
+          trimmedLine.startsWith("//") ||
+          trimmedLine.startsWith("*") ||
+          trimmedLine.startsWith("/*") ||
+          trimmedLine === ""
+        ) {
+          return;
+        }
+
+        // Detect import/require patterns for better-call
+        const importPatterns = [
+          /from\s+["']better-call["']/,
+          /import\s+.*["']better-call["']/,
+          /require\s*\(\s*["']better-call["']\s*\)/,
+        ];
+
+        if (importPatterns.some((pattern) => pattern.test(line))) {
+          betterCallImports.push(`Line ${index + 1}: ${line.trim()}`);
+        }
+      });
+
+      if (betterCallImports.length > 0) {
+        violatingFiles.push({
+          file: relative(process.cwd(), file),
+          lines: betterCallImports,
+        });
+      }
+    }
+
+    if (violatingFiles.length > 0) {
+      const errorMessage = [
+        "Found better-call imports in source files:",
+        "",
+        ...violatingFiles.flatMap(({ file, lines }) => [
+          `${file}:`,
+          ...lines.map((line) => `  ${line}`),
+          "",
+        ]),
+        "The feature-flags plugin should not import from better-call.",
+        "All middleware functionality has been moved to internal implementation.",
+        "",
+        "If you need functionality from better-call:",
+        "1. Check if it's already available in src/middleware/",
+        "2. Implement the needed functionality internally",
+        "3. Update this test if better-call becomes a required dependency again",
+      ].join("\n");
+
+      throw new Error(errorMessage);
+    }
+
+    console.log(
+      `✅ Verified ${sourceFiles.length} source files contain no better-call imports`,
+    );
+  });
+});
+
+/** Recursively collects all TypeScript/JavaScript files from directory tree */
+async function getAllSourceFiles(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await getAllSourceFiles(fullPath)));
+    } else if (entry.isFile() && /\.(ts|tsx|js|jsx)$/.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}


### PR DESCRIPTION
## Summary

- Remove `better-call` as peer dependency from feature-flags plugin
- Add architectural test to prevent better-call imports
- Improve `isEnabled()` type safety with proper boolean flag filtering
- Export missing client types for better developer experience
- Update documentation to reflect simplified dependency model

## Core Improvements

- **Dependency reduction**: Eliminates `better-call` peer dependency, reducing bundle size and complexity
- **Type safety**: Enhanced `isEnabled()` method now properly restricts to boolean flags only using `BooleanFlags<Schema>` utility type
- **DX improvements**: Export client types (`FeatureFlagResult`, `FeatureFlagsClient`, etc.) for better TypeScript support
- **Architecture enforcement**: New test prevents accidental better-call imports, maintaining clean internal implementation

## Changes

- Remove better-call from installation instructions across docs and README
- Add `no-better-call-imports.test.ts` to enforce dependency boundaries
- Improve client type exports in main index
- Version bump to 0.2.2
- Simplify peer dependency messaging in documentation

Fixes TypeScript complexity issues while maintaining full functionality through internal middleware implementation.