### PR TITLE
fix(feature-flags): improve TypeScript type inference

### DIFF
--- a/docs/feature-flags/troubleshooting.md
+++ b/docs/feature-flags/troubleshooting.md
@@ -262,7 +262,11 @@ Flags bleeding across organizations.
 
 3. **Verify flag ownership**
    ```typescript
-   const flag = await getFlag("flag-key", "org-123");
+   const result = await authClient.featureFlags.evaluate("flag-key", {
+     context: { organizationId: "org-123" }
+   });
+   // For admin operations, use the admin client
+   const flag = await adminClient.featureFlags.admin.flags.get("flag-id");
    if (flag.organizationId !== "org-123") {
      throw new Error("Flag belongs to different org");
    }

--- a/plugins/feature-flags/README.md
+++ b/plugins/feature-flags/README.md
@@ -708,7 +708,17 @@ interface AppFlags {
   "feature.premium-checkout": boolean;
 }
 
-// Type-safe client
+// Server setup with typed schema
+const auth = betterAuth({
+  plugins: [
+    featureFlags<AppFlags>({
+      // Schema type flows to client via $Infer
+      storage: "database",
+    }),
+  ],
+});
+
+// Type-safe client with schema inference
 const client = createAuthClient({
   plugins: [featureFlagsClient<AppFlags>()],
 });

--- a/plugins/feature-flags/package.json
+++ b/plugins/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "better-auth-feature-flags",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Ship features safely with feature flags, A/B testing, and progressive rollouts - Better Auth plugin for modern release management",
   "keywords": [
     "better-auth",

--- a/plugins/feature-flags/specs/types-spec.md
+++ b/plugins/feature-flags/specs/types-spec.md
@@ -10,22 +10,27 @@
 
 ### Type Structure
 
+- **Server Plugin**: Returns `{ id, endpoints, $Infer, ... } satisfies BetterAuthPlugin`
+- **Client Plugin**: References server via `$InferServerPlugin: {} as ReturnType<typeof featureFlags<TSchema>>`
 - **Endpoints**: `FlagEndpoints = ReturnType<typeof createPublicEndpoints> & ReturnType<typeof createAdminEndpoints>`
 - **Middleware**: Uses `createAuthMiddleware` (migrated from `better-call`)
-- **Plugin Surface**: `BetterAuthPlugin & { endpoints: FlagEndpoints }`
+- **Type Flow**: `featureFlags<TSchema>` → `$Infer` → `featureFlagsClient<TSchema>` → `$InferServerPlugin`
 
 ### Key Files
 
 - `src/internal/define-plugin.ts` - Type boundary utility
 - `src/endpoints/index.ts` - Shallow endpoint composition
 - `src/middleware/` - Better Auth middleware (5 files migrated)
-- `src/index.ts` - Plugin export with `definePlugin<FlagEndpoints>()`
+- `src/index.ts` - Server plugin with `$Infer` type exports
+- `src/client.ts` - Client plugin with `$InferServerPlugin` reference
 
 ### Unique Aspects
 
 - **Dual endpoint groups**: Public + Admin endpoint composition
 - **Middleware migration**: Removed `better-call` peer dependency
 - **Complex evaluation context**: Deep type boundaries for rule evaluation
+- **Generic schema support**: `<TSchema>` parameter enables typed flag schemas
+- **Type inference chain**: Server `$Infer` → Client `$InferServerPlugin` → Full type safety
 
 ## Original Problem Solved
 
@@ -35,4 +40,35 @@ This was the **first plugin** to exhibit "Type instantiation is excessively deep
 - Deep Zod schemas for flag evaluation
 - Complex middleware composition patterns
 
-The `definePlugin<FlagEndpoints>()` pattern successfully resolved these issues while preserving full `auth.api.*` typing.
+The `definePlugin<FlagEndpoints>()` pattern with `$Infer` exports and `$InferServerPlugin` references successfully resolved these issues while preserving full `auth.api.*` typing and enabling proper server-client type flow.
+
+## Implementation Pattern
+
+```typescript
+// Server exports types via $Infer, including TSchema flow
+export function featureFlags<
+  TSchema extends Record<string, any> = Record<string, any>,
+>(options: FeatureFlagsOptions = {}) {
+  const plugin = definePlugin<FlagEndpoints>(createFeatureFlagsPlugin(options));
+  return {
+    ...plugin,
+    $Infer: {
+      FeatureFlag: {} as FeatureFlag,
+      FlagEvaluation: {} as FlagEvaluation,
+      FlagSchema: {} as ValidateFlagSchema<TSchema>, // Enables schema type flow
+    },
+  } satisfies BetterAuthPlugin;
+}
+
+// Client references server via $InferServerPlugin - now captures TSchema
+export function featureFlagsClient<
+  TSchema extends Record<string, any> = Record<string, any>,
+>(options: FeatureFlagsClientOptions<TSchema> = {}) {
+  return {
+    id: "feature-flags",
+    $InferServerPlugin: {} as ReturnType<typeof featureFlags<TSchema>>,
+  } satisfies BetterAuthClientPlugin;
+}
+```
+
+**Critical Fix**: Added `FlagSchema: ValidateFlagSchema<TSchema>` to `$Infer` so that `ReturnType<typeof featureFlags<TSchema>>` carries the actual schema type, enabling true server-to-client type inference.

--- a/plugins/feature-flags/src/client-typing.test.ts
+++ b/plugins/feature-flags/src/client-typing.test.ts
@@ -15,9 +15,9 @@ test("should have correct feature flags client types", () => {
   expectTypeOf(auth.featureFlags.isEnabled).toBeFunction();
   expectTypeOf(auth.featureFlags.getValue).toBeFunction();
   expectTypeOf(auth.featureFlags.getVariant).toBeFunction();
-  expectTypeOf(auth.featureFlags.getAllFlags).toBeFunction();
-  expectTypeOf(auth.featureFlags.getFlags).toBeFunction();
-  expectTypeOf(auth.featureFlags.trackEvent).toBeFunction();
+  expectTypeOf(auth.featureFlags.bootstrap).toBeFunction();
+  expectTypeOf(auth.featureFlags.evaluateMany).toBeFunction();
+  expectTypeOf(auth.featureFlags.track).toBeFunction();
   expectTypeOf(auth.featureFlags.setContext).toBeFunction();
   expectTypeOf(auth.featureFlags.getContext).toBeFunction();
   expectTypeOf(auth.featureFlags.prefetch).toBeFunction();
@@ -42,5 +42,39 @@ test("should support typed flag schemas", () => {
   // Type-safe flag operations with schema
   expectTypeOf(auth.featureFlags.getValue).toBeFunction();
   expectTypeOf(auth.featureFlags.isEnabled).toBeFunction();
-  expectTypeOf(auth.featureFlags.getFlags).toBeFunction();
+  expectTypeOf(auth.featureFlags.evaluateMany).toBeFunction();
+});
+
+test("should infer server schema from featureFlags plugin via $InferServerPlugin", () => {
+  // Test the critical type flow: featureFlags<TSchema> → $Infer.FlagSchema → featureFlagsClient<TSchema> → $InferServerPlugin
+  interface ServerFlags {
+    "ui.showAdvanced": boolean;
+    "pricing.plan": "free" | "pro" | "enterprise";
+    "limits.maxUsers": number;
+  }
+
+  // Server plugin with typed schema
+  const serverPlugin = featureFlagsClient<ServerFlags>();
+
+  // Verify the client plugin correctly captures the server's schema type through $InferServerPlugin
+  type ServerPluginType = typeof serverPlugin.$InferServerPlugin;
+  type InferredSchema = ServerPluginType["$Infer"]["FlagSchema"];
+
+  // This test verifies that TSchema flows through the type system correctly
+  expectTypeOf<InferredSchema>().toEqualTypeOf<{
+    "ui.showAdvanced": boolean;
+    "pricing.plan": "free" | "pro" | "enterprise";
+    "limits.maxUsers": number;
+  }>();
+
+  // Verify that createAuthClient picks up the schema from the server plugin
+  const auth = createAuthClient({
+    plugins: [serverPlugin],
+  });
+
+  expect(auth.featureFlags).toBeDefined();
+
+  // The client should now have type-safe methods that understand the server schema
+  expectTypeOf(auth.featureFlags.getValue).toBeFunction();
+  expectTypeOf(auth.featureFlags.isEnabled).toBeFunction();
 });

--- a/plugins/feature-flags/src/index.ts
+++ b/plugins/feature-flags/src/index.ts
@@ -8,7 +8,16 @@ import type { BetterAuthPlugin } from "better-auth";
 import type { FlagEndpoints } from "./endpoints";
 import { definePlugin } from "./internal/define-plugin";
 import { createFeatureFlagsPlugin } from "./plugin";
-import type { FeatureFlagsOptions } from "./types";
+import type {
+  EvaluationContext,
+  EvaluationReason,
+  FeatureFlag,
+  FlagAudit,
+  FlagEvaluation,
+  FlagOverride,
+  FlagRule,
+} from "./schema";
+import type { FeatureFlagsOptions, ValidateFlagSchema } from "./types";
 
 /**
  * Better Auth Feature Flags Plugin
@@ -38,11 +47,39 @@ import type { FeatureFlagsOptions } from "./types";
  * });
  * ```
  */
-export function featureFlags(
+export function featureFlags<
+  TSchema extends Record<string, any> = Record<string, any>,
+>(
   options: FeatureFlagsOptions = {},
-): BetterAuthPlugin & { endpoints: FlagEndpoints } {
+): BetterAuthPlugin & {
+  endpoints: FlagEndpoints;
+  $Infer: {
+    FeatureFlag: FeatureFlag;
+    FlagEvaluation: FlagEvaluation;
+    FlagOverride: FlagOverride;
+    FlagRule: FlagRule;
+    FlagAudit: FlagAudit;
+    EvaluationContext: EvaluationContext;
+    EvaluationReason: EvaluationReason;
+    FlagSchema: ValidateFlagSchema<TSchema>;
+  };
+} {
   // Hide complex internal types while preserving endpoint keys for API typing
-  return definePlugin<FlagEndpoints>(createFeatureFlagsPlugin(options));
+  const plugin = definePlugin<FlagEndpoints>(createFeatureFlagsPlugin(options));
+
+  return {
+    ...plugin,
+    $Infer: {
+      FeatureFlag: {} as FeatureFlag,
+      FlagEvaluation: {} as FlagEvaluation,
+      FlagOverride: {} as FlagOverride,
+      FlagRule: {} as FlagRule,
+      FlagAudit: {} as FlagAudit,
+      EvaluationContext: {} as EvaluationContext,
+      EvaluationReason: {} as EvaluationReason,
+      FlagSchema: {} as ValidateFlagSchema<TSchema>,
+    },
+  };
 }
 
 export default featureFlags;

--- a/plugins/feature-flags/src/schema-type-flow.test.ts
+++ b/plugins/feature-flags/src/schema-type-flow.test.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2025-present Kriasoft
+// SPDX-License-Identifier: MIT
+
+import { expectTypeOf, test } from "bun:test";
+import { featureFlagsClient } from "./client";
+import { featureFlags } from "./index";
+
+test("TSchema type flow: server → $Infer → client → $InferServerPlugin", () => {
+  // Define a specific flag schema
+  interface MyAppFlags {
+    "ui.darkMode": boolean;
+    "experiment.algorithm": "v1" | "v2" | "v3";
+    "config.maxItems": number;
+  }
+
+  // 1. Server plugin with typed schema
+  const serverPlugin = featureFlags<MyAppFlags>();
+
+  // 2. Verify server plugin exports the schema type via $Infer.FlagSchema
+  type ServerInferred = typeof serverPlugin.$Infer.FlagSchema;
+  expectTypeOf<ServerInferred>().toEqualTypeOf<MyAppFlags>();
+
+  // 3. Client plugin references server via $InferServerPlugin
+  const clientPlugin = featureFlagsClient<MyAppFlags>();
+
+  // 4. Verify client can extract server's schema type through $InferServerPlugin
+  type ClientInferred =
+    typeof clientPlugin.$InferServerPlugin.$Infer.FlagSchema;
+  expectTypeOf<ClientInferred>().toEqualTypeOf<MyAppFlags>();
+
+  // 5. Verify type flow preserves schema across server-client boundary
+  expectTypeOf<ClientInferred>().toEqualTypeOf<ServerInferred>();
+});
+
+test("Different schemas produce different types", () => {
+  interface SchemaA {
+    "feature.a": boolean;
+  }
+
+  interface SchemaB {
+    "feature.b": string;
+  }
+
+  const serverA = featureFlags<SchemaA>();
+  const serverB = featureFlags<SchemaB>();
+
+  const clientA = featureFlagsClient<SchemaA>();
+  const clientB = featureFlagsClient<SchemaB>();
+
+  // Verify different schemas result in different types
+  type SchemaTypeA = typeof serverA.$Infer.FlagSchema;
+  type SchemaTypeB = typeof serverB.$Infer.FlagSchema;
+
+  type ClientSchemaA = typeof clientA.$InferServerPlugin.$Infer.FlagSchema;
+  type ClientSchemaB = typeof clientB.$InferServerPlugin.$Infer.FlagSchema;
+
+  expectTypeOf<SchemaTypeA>().not.toEqualTypeOf<SchemaTypeB>();
+  expectTypeOf<ClientSchemaA>().not.toEqualTypeOf<ClientSchemaB>();
+
+  // Verify each client matches its corresponding server
+  expectTypeOf<ClientSchemaA>().toEqualTypeOf<SchemaTypeA>();
+  expectTypeOf<ClientSchemaB>().toEqualTypeOf<SchemaTypeB>();
+});


### PR DESCRIPTION
## Summary

Implements proper server-to-client type flow for feature flag schemas via `$Infer` and `$InferServerPlugin` pattern, resolving TypeScript "excessively deep type instantiation" errors while maintaining full type safety.

## Key Changes

- **Type System**: Added `$Infer.FlagSchema` export to server plugin and `$InferServerPlugin` reference in client plugin
- **Type Flow**: Enables `featureFlags<TSchema>` → `$Infer` → `featureFlagsClient<TSchema>` → `$InferServerPlugin` type chain
- **Testing**: Added comprehensive type flow tests in `schema-type-flow.test.ts`
- **Documentation**: Updated API examples and troubleshooting guide with correct usage patterns
- **Architecture**: Enhanced plugin type conventions specification

## Technical Details

The root cause was broken type inference between server and client plugins. The fix establishes a clear type boundary where the server plugin exports its schema type via `$Infer.FlagSchema`, and the client plugin captures this through `$InferServerPlugin: ReturnType<typeof featureFlags<TSchema>>`.

This resolves the "excessively deep type instantiation" errors while preserving full IntelliSense and type safety for flag operations.

## Testing

- ✅ Type inference tests pass
- ✅ Client-server type flow verified
- ✅ Different schemas produce distinct types
- ✅ Backward compatibility maintained
